### PR TITLE
Fix a typo in config.md

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -239,7 +239,7 @@ overrides:
     rename:
       id: "Identifier"
     overrides:
-      - db_type: "timestampz"
+      - db_type: "timestamptz"
         nullable: true
         engine: "postgresql"
         go_type:


### PR DESCRIPTION
Hi all,
I believe the value of the `db_type` key in the config.md should be changed from `"timestampz"` to `"timestamptz"`.
Thanks for creating this awesome package 🙂